### PR TITLE
chore: automerge all non-major renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>henrist/renovate-config:default",
-    "github>henrist/renovate-config:automated",
+    "github>henrist/renovate-config:automated-aggressive",
     "customManagers:biomeVersions"
   ]
 }


### PR DESCRIPTION
Switch to the automated-aggressive preset so Renovate automerges all minor/patch/digest updates (incl. prod deps like react), not just devDependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPQbgMfnZ7MAerZFmQGaEY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to use a more aggressive preset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->